### PR TITLE
update github.com/golang-jwt/jwt/v4 and DecodePaddingAllowed is true

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/fujiwara/go-amzn-oidc
 go 1.14
 
 require (
-	github.com/golang-jwt/jwt v3.2.1+incompatible
+	github.com/golang-jwt/jwt/v4 v4.4.3
 	github.com/hashicorp/logutils v1.0.0
 	github.com/onsi/ginkgo v1.14.2 // indirect
 	github.com/onsi/gomega v1.10.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
-github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=

--- a/validator/http.go
+++ b/validator/http.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // NewHTTPHandlerFunc creates http handler func with timeout

--- a/validator/http_test.go
+++ b/validator/http_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/fujiwara/go-amzn-oidc/validator"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 func TestHTTPHandlerFunc(t *testing.T) {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -10,10 +10,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 	"github.com/shogo82148/go-retry"
 )
+
+func init() {
+	jwt.DecodePaddingAllowed = true
+}
 
 // RetryPolicy represents a policy for retrying http request to key URL.
 var RetryPolicy = retry.Policy{

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/fujiwara/go-amzn-oidc/validator"
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 var privateKey, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)


### PR DESCRIPTION
Unfortunately, the JWT for x-amzn-oidc-data coming from the ALB does not seem to follow RFC7515.

Specifically, each segment is base64 encoded with padding.
So, we will include a response for this.